### PR TITLE
fix: update links to correct open source starter guide path

### DIFF
--- a/src/components/about.jsx
+++ b/src/components/about.jsx
@@ -51,7 +51,7 @@ const About = () => {
             For a step-by-step walkthrough on contributing to the Open Source
             Devs project, follow the guide{' '}
             <Link
-              href='https://www.getscriptordietryin.com/contributing-to-open-source-made-simple-a-starter-guide'
+              href='https://www.getscriptordietryin.com/contributing-to-open-source-starter-guide'
               target='_blank'
               rel='noopener noreferrer'
             >

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -30,7 +30,7 @@ export default function Footer() {
         >
           Get started{' '}
           <Link
-            href='https://www.getscriptordietryin.com/contributing-to-open-source-made-simple-a-starter-guide'
+            href='https://www.getscriptordietryin.com/contributing-to-open-source-starter-guide'
             target='_blank'
             rel='noopener noreferrer'
           >


### PR DESCRIPTION
This link enhancement points to the updated prod URL for the Contributing to Open Source Starter Guide article.