### PR TITLE
🎨:Navbar to black

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -13,7 +13,8 @@ const navLinkStyle = {
 export default function Navbar() {
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <AppBar position='static' color='primary'>
+      {/*!!WARN: Best practice would be to use a *theme* color, not hardcoded as below */}
+      <AppBar position='static' color='primary' sx={{ bgcolor: '#000000' }}>
         <Toolbar>
           <Typography variant='h6' component='div' sx={{ flexGrow: 1 }}>
             <Link to='/' style={navLinkStyle}>


### PR DESCRIPTION
Fix for #12
⚠️ - Implementing #13 (depending on how @rohitkothapalli does it) will probably have an effect on this, so make sure going to dark-mode doesn't result in a black-text-on-black-background.