### PR TITLE
Fix vertical alignment in a large window

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -23,7 +23,7 @@ function Copyright() {
 export default function Footer() {
   return (
     <>
-      <Box sx={{ bgcolor: 'background.paper', p: 6 }} component='footer'>
+      <Box sx={{ bgcolor: 'background.paper', p: 6, display: "flex", flexGrow: 1, flexDirection: "column", justifyContent: "end" }} component='footer'>
         <Typography variant='h6' align='center' gutterBottom>
           Want to contribute?
         </Typography>

--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -27,7 +27,7 @@ const innerItem = {
 
 export default function Navbar() {
   return (
-    <Box sx={{ flexGrow: 1 }}>
+    <Box>
       {/*!!WARN: Best practice would be to use a *theme* color, not hardcoded as below */}
       <AppBar position="static" color="primary" sx={{ bgcolor: "#000000" }}>
         <Toolbar style={menuBarFlex}>


### PR DESCRIPTION
Grows footer instead of navbar flex when the window is larger than the content.
This allows the main content to be just below the navbar instead of at the
bottom. Footer content is pinned to the bottom of the window.