### PR TITLE
Fix: User view DevCard bottom is cut off

### DIFF
--- a/src/components/dev-card.jsx
+++ b/src/components/dev-card.jsx
@@ -21,7 +21,7 @@ export default function DevCard({ profile }) {
   const location = useLocation();
 
   return (
-    <Card sx={{ maxWidth: 345, textAlign: "center" }}>
+    <Card sx={{ maxWidth: 345, textAlign: "center", marginBottom: "4px" }}>
       <Link
         to={`users/${profile.githubUsername}`}
         style={location.pathname === "/" ? enabledLink : disabledLink}


### PR DESCRIPTION
Adds a 4px margin-bottom to DevCard so the border and shadow won't be cut off.

Not normally seen on the main page because the grid has extra padding.

Before | After
-|-
![before_card](https://user-images.githubusercontent.com/70560944/137547757-e15e8baa-31da-4309-82ab-87ffa9b61a5d.png) | ![after_card](https://user-images.githubusercontent.com/70560944/137547795-ca44c03b-0593-469d-9931-cf6a76f98ecc.png)